### PR TITLE
Fallback to TFLM processing logic for per-channel data in FullyConnected

### DIFF
--- a/tensorflow/lite/micro/kernels/esp_nn/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/esp_nn/fully_connected.cc
@@ -153,6 +153,21 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
           break;
         }
         case kTfLiteInt8: {
+          if (data.is_per_channel) {
+            // Optimisations for per_channel data haven't been implemented yet, so fallback to TFLM's own implementation
+            tflite::reference_integer_ops::FullyConnectedPerChannel(
+              FullyConnectedParamsQuantized(data),
+              data.per_channel_output_multiplier,
+              reinterpret_cast<const int*>(data.per_channel_output_shift),
+              tflite::micro::GetTensorShape(input),
+              tflite::micro::GetTensorData<int8_t>(input),
+              tflite::micro::GetTensorShape(filter),
+              tflite::micro::GetTensorData<int8_t>(filter),
+              tflite::micro::GetTensorShape(bias),
+              tflite::micro::GetOptionalTensorData<int32_t>(bias),
+              tflite::micro::GetTensorShape(output),
+              tflite::micro::GetTensorData<int8_t>(output));
+          } else {
 #if ESP_NN
           const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
           const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -197,6 +212,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
               tflite::micro::GetTensorShape(output),
               tflite::micro::GetTensorData<int8_t>(output));
 #endif
+          }
           break;
         }
         default: {


### PR DESCRIPTION
- ESP-NN currently does not have a function for per-channel data
- Using the existing method gives incorrect outputs
- Fallback to TFLM implementation in such cases

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
TFLM has a separate `FullyConnectedPerChannel` implementation for per-channel data. There existing ESP-NN method used for this data and gives incorrect outputs. Therefore, if `data.is_per_channel` is true then fallback to TFLM implementation for the time being.

## Testing
Test ran a MobileNetV2 quantized model and compared its expected and actual outputs after this fix.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
