### PR TITLE
Fixed incorrect Init logic for ESP-NN Conv2D Kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/esp_nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/esp_nn/conv.cc
@@ -45,7 +45,7 @@ struct NodeData {
 
 static void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-  return context->AllocatePersistentBuffer(context, sizeof(OpDataConv));
+  return context->AllocatePersistentBuffer(context, sizeof(NodeData));
 }
 
 static TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {


### PR DESCRIPTION

## Description
- Init method was initialisating a persistent buffer equal to size of OpDataConv while the correct size would be that of NodeData which is used by ESP-NN
- This had knock-on effects in other places, e.g. when running quantized MobileNetV2 model this led to the Softmax Node's beta param getting overridden.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
